### PR TITLE
Add bash-completion

### DIFF
--- a/bash-completion/completions/vpm
+++ b/bash-completion/completions/vpm
@@ -1,0 +1,43 @@
+source /usr/share/bash-completion/completions/xbps
+
+_vpm()
+{
+    local cur prev words cword
+    _init_completion || return
+    
+    local subcommands='sync
+	update
+	listrepos
+	repolist
+	addrepo
+	info
+	filelist
+	deps
+	reverse
+	search
+	searchfile
+	list
+	install
+	devinstall
+	listalternatives
+	setalternative
+	reconfigure
+	forceinstall
+	remove
+	removerecursive
+	cleanup
+	autoremove
+	help
+	helppager'
+    local all_pkgs='info|filelist|deps|reverse|search|install|devinstall'
+    local installed_pkgs='listalternatives|setalternative|reconfigure|forceinstall|remove|removerecursive'
+
+    if [[ $prev == @($1) ]]; then
+      COMPREPLY=( $( compgen -W "$subcommands" -- "$cur") )
+    elif [[ $prev == @($all_pkgs) ]]; then
+    	COMPREPLY=( $(compgen -W '$(_xbps_all_packages)' -- "$cur") )
+    elif [[ $prev == @($installed_pkgs) ]]; then
+    	COMPREPLY=( $(compgen -W '$(_xbps_installed_packages)' -- "$cur") )
+    fi
+} &&
+complete -F _vpm vpm


### PR DESCRIPTION
This assumes that we will be installing to a Void Linux system with 'bash-completion' package installed.
Notes:
- sourcing the xbps bash completion for forward proofing.
- calling out to `_xbps_all_packages` and `_xbps_installed_packages` directly, as `_xbps_complete` expects $1 to be one of the xbps-* commnads.
- none of the extra `-args` are implemented due to the hardcoded $1 problem mentioned above.